### PR TITLE
Redirect certain routes to the latest package versions.

### DIFF
--- a/pages/packages/[package]/functions/[function].tsx
+++ b/pages/packages/[package]/functions/[function].tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next';
+
+import { API_URL } from '../../../../lib/utils';
+
+export default function genericFunctionPage() {
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params: { function: functionName, package: packageName },
+}) => {
+  try {
+    const res = await fetch(`${API_URL}/api/packages/${packageName}`);
+    const data = await res.json();
+
+    // if package is found, get the latest version
+    const latestVersion = data.versions.find(
+      (version) => version.id === data.latest_version_id,
+    ).version;
+
+    // return a temporary redirect to the latest version
+    return {
+      redirect: {
+        destination: `/packages/${packageName}/versions/${latestVersion}/topics/${functionName}`,
+        permanent: false,
+      },
+    };
+  } catch (error) {
+    // if package doesn't exist, return a 404
+    return {
+      notFound: true,
+    };
+  }
+};

--- a/pages/packages/[package]/topics/[topic].tsx
+++ b/pages/packages/[package]/topics/[topic].tsx
@@ -1,0 +1,34 @@
+import { GetServerSideProps } from 'next';
+
+import { API_URL } from '../../../../lib/utils';
+
+export default function genericTopicPage() {
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params: { package: packageName, topic: topicName },
+}) => {
+  try {
+    const res = await fetch(`${API_URL}/api/packages/${packageName}`);
+    const data = await res.json();
+
+    // if package is found, get the latest version
+    const latestVersion = data.versions.find(
+      (version) => version.id === data.latest_version_id,
+    ).version;
+
+    // return a temporary redirect to the latest version
+    return {
+      redirect: {
+        destination: `/packages/${packageName}/versions/${latestVersion}/topics/${topicName}`,
+        permanent: false,
+      },
+    };
+  } catch (error) {
+    // if package doesn't exist, return a 404
+    return {
+      notFound: true,
+    };
+  }
+};


### PR DESCRIPTION
Disclaimer: not a very clean solution, just trying to resolve the issue flagged by @richierocks: ASAP

Links of the form 
https://www.rdocumentation.org/packages/package_name/topics/function_name
or
https://www.rdocumentation.org/packages/package_name/functions/function_name
no longer work. They need to redirect to
https://www.rdocumentation.org/packages/package_name/versions/version_number/topics/function_name 

That is, if no version was provided, the latest version of the package would be shown.