### PR TITLE
Update base font-size from 16px to 14px

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -10,6 +10,10 @@
   input {
     @apply shadow-none;
   }
+
+  html {
+    font-size: 14px;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
1. Default font-size went from 16px to 14px to accommodate smaller screen sizes.
2. Everything scales accordingly.

Screenshots on 125% zoom:

Before:
![image](https://user-images.githubusercontent.com/3189648/113597555-2c473380-963c-11eb-9183-c5ef37dfc87f.png)

After:
![image](https://user-images.githubusercontent.com/3189648/113597596-3a954f80-963c-11eb-8687-a7d5ef5baa8b.png)
