### PR TITLE
fix: fix broken links in the “See Also” section

### DIFF
--- a/pages/link/[topic].tsx
+++ b/pages/link/[topic].tsx
@@ -1,0 +1,28 @@
+import { GetServerSideProps } from 'next';
+import { API_URL } from '../../lib/utils';
+
+export default function genericLinkPage() {
+  return null;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({
+  params: { topic },
+  query: { package: packageName, version },
+}) => {
+  try {
+    const res = await fetch(
+      `${API_URL}/link/${topic}?package=${packageName}&version=${version}`,
+    );
+
+    return {
+      redirect: {
+        destination: res.url.replace(API_URL, ''),
+        permanent: false,
+      },
+    };
+  } catch (error) {
+    return {
+      notFound: true,
+    };
+  }
+};


### PR DESCRIPTION
The links in the “See Also” section on topic pages lead to a 404. This is very annoying since RDocumentation is often the first result for searches related to R packages. The missing page is:

`/link/:topic?package=:package&version=:version`

And it should point to:

`/packages/:package/versions/:version/topics/:topic`

However, It can’t be simply fixed by redirecting to the correct URL because the function names in the “See Also” section don’t always map directly to topic pages. There is an [API endpoint](https://github.com/datacamp/RDocumentation-app/blob/aa71a42af087a850df69d5c7ecbc01316cc31f0e/api/controllers/TopicController.js#L263-L367) with the same path that resolves the correct topic page and fallbacks with a search results:

`[API_URL]/link/:topic?package=:package&version=:version`

The problem is, it redirects to a page in the API domain, instead of returning JSON with a correct relative URL.

`[API_URL]/packages/:package/versions/:version/topics/:topic`

**The solution:** create the link page and fetch the corresponding API endpoint, get the URL it redirects to from response.url, strip the domain name and redirect.

This can be improved further by adding an API endpoint that returns the correct URL or by resolving the URL when the link is created thus saving on two redirects.

This solves #65 and #74.