### PR TITLE
Add "Run in workspace" button in Example code cells

### DIFF
--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -149,6 +149,15 @@ export default function TopicPage({ topicData }: Props) {
                   Run in Workspace
                 </a>
                 <pre>{examples}</pre>
+                <p>
+                  Instantly run the code above in your browser using{' '}
+                  <a
+                    href={`https://www.datacamp.com/workspace?utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    target="_blank"
+                  >
+                    DataCamp Workspace
+                  </a>
+                </p>
               </div>
             </section>
           )}

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -137,7 +137,7 @@ export default function TopicPage({ topicData }: Props) {
                 <h2>Examples</h2>
                 <a
                   className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                  href={`https://www.datacamp.com/workspace?utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                  href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                   style={{
                     background: 'rgba(3, 239, 98)',
                     color: '#1f2937',
@@ -152,7 +152,7 @@ export default function TopicPage({ topicData }: Props) {
                 <p>
                   Instantly run the code above in your browser using{' '}
                   <a
-                    href={`https://www.datacamp.com/workspace?utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                     target="_blank"
                   >
                     DataCamp Workspace

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -1,5 +1,6 @@
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 
 import Html from '../../../../../../components/Html';
 import Layout from '../../../../../../components/Layout';
@@ -45,6 +46,8 @@ export default function TopicPage({ topicData }: Props) {
     usage,
     value,
   } = topicData;
+  const router = useRouter();
+  const { topic } = router.query;
   return (
     <Layout
       canonicalLink={canonicalLink}
@@ -130,8 +133,23 @@ export default function TopicPage({ topicData }: Props) {
           )}
           {examples && (
             <section>
-              <h2>Examples</h2>
-              <pre>{examples}</pre>
+              <div className="relative">
+                <h2>Examples</h2>
+                <a
+                  className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
+                  href={`https://www.datacamp.com/workspace?utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                  style={{
+                    background: 'rgba(3, 239, 98)',
+                    color: '#1f2937',
+                    fontWeight: 600,
+                    textDecoration: 'none',
+                  }}
+                  target="_blank"
+                >
+                  Run in Workspace
+                </a>
+                <pre>{examples}</pre>
+              </div>
             </section>
           )}
         </div>


### PR DESCRIPTION
## Ticket
[CT-2374](https://datacamp.atlassian.net/browse/CT-2374)

## Description
This is a growth experiment to bring visitors to workspace.
- Add a button "Run in workspace" in each example code cell. For now this will just send people to the workspace landing page as we don't have a way to create a workspace from a block of code. If we notice good traction, this will be a follow up to implement this feature.
- Add a link to workspace below each example code cell

## Screenshots

On desktop:
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/38893718/153626391-1cf4dd86-79b5-4b8e-89f0-a55e26bd1066.png">

On phone:
<img width="366" alt="image" src="https://user-images.githubusercontent.com/38893718/153626656-b9f1fc32-2742-4019-b8bb-b60f6a9cb04f.png">
