### PR TITLE
feat: added rdcos path and title in the params for opening in workspace

### DIFF
--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -48,9 +48,10 @@ export default function TopicPage({ topicData }: Props) {
   } = topicData;
   const router = useRouter();
   const { topic } = router.query;
-  const rdocsPath = encodeURI(
+  const rdocsPath = encodeURIComponent(
     `packages/${packageName}/versions/${packageVersion}/topics/${topic}`,
   );
+
   return (
     <Layout
       canonicalLink={canonicalLink}

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -48,7 +48,9 @@ export default function TopicPage({ topicData }: Props) {
   } = topicData;
   const router = useRouter();
   const { topic } = router.query;
-  const rdocsPath = `packages/${packageName}/versions/${packageVersion}/topics/${topic}`;
+  const rdocsPath = encodeURI(
+    `packages/${packageName}/versions/${packageVersion}/topics/${topic}`,
+  );
   return (
     <Layout
       canonicalLink={canonicalLink}
@@ -138,7 +140,7 @@ export default function TopicPage({ topicData }: Props) {
                 <h2>Examples</h2>
                 <a
                   className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                  href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base-rdocs&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace&rdocsPath=${rdocsPath}&rdocsTitle=${name}:${title}`}
+                  href={`https://app.datacamp-staging.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                   style={{
                     background: 'rgba(3, 239, 98)',
                     color: '#1f2937',
@@ -153,7 +155,7 @@ export default function TopicPage({ topicData }: Props) {
                 <p>
                   Instantly run the code above in your browser using{' '}
                   <a
-                    href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base-rdocs&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace&rdocsPath=${rdocsPath}&rdocsTitle=${name}:${title}`}
+                    href={`https://app.datacamp-staging.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                     target="_blank"
                   >
                     DataCamp Workspace

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -48,6 +48,7 @@ export default function TopicPage({ topicData }: Props) {
   } = topicData;
   const router = useRouter();
   const { topic } = router.query;
+  const rdocsPath = `packages/${packageName}/versions/${packageVersion}/topics/${topic}`;
   return (
     <Layout
       canonicalLink={canonicalLink}
@@ -137,7 +138,7 @@ export default function TopicPage({ topicData }: Props) {
                 <h2>Examples</h2>
                 <a
                   className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                  href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base-rdocs&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                  href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base-rdocs&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace&rdocsPath=${rdocsPath}&rdocsTitle=${name}:${title}`}
                   style={{
                     background: 'rgba(3, 239, 98)',
                     color: '#1f2937',
@@ -152,7 +153,7 @@ export default function TopicPage({ topicData }: Props) {
                 <p>
                   Instantly run the code above in your browser using{' '}
                   <a
-                    href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base-rdocs&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    href={`https://app.datacamp.com/workspace/new?_tag=template&templateKey=r-base-rdocs&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace&rdocsPath=${rdocsPath}&rdocsTitle=${name}:${title}`}
                     target="_blank"
                   >
                     DataCamp Workspace

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -141,7 +141,7 @@ export default function TopicPage({ topicData }: Props) {
                 <h2>Examples</h2>
                 <a
                   className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                  href={`https://app.datacamp-staging.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                  href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                   style={{
                     background: 'rgba(3, 239, 98)',
                     color: '#1f2937',
@@ -156,7 +156,7 @@ export default function TopicPage({ topicData }: Props) {
                 <p>
                   Instantly run the code above in your browser using{' '}
                   <a
-                    href={`https://app.datacamp-staging.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                     target="_blank"
                   >
                     DataCamp Workspace


### PR DESCRIPTION
Fixes [CT-2476](https://datacamp.atlassian.net/browse/CT-2476)

We now send the rdocs path in the params which will be used to access the api endpoint to retrieve the example code for pre populating a workspace. Now also send the title of the page. 