### PR TITLE
feat: removed workspace button and changed url to direct to landing page

### DIFF
--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -139,26 +139,10 @@ export default function TopicPage({ topicData }: Props) {
             <section>
               <div className="relative">
                 <h2>Examples</h2>
-                <a
-                  className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                  href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
-                  style={{
-                    background: 'rgba(3, 239, 98)',
-                    color: '#1f2937',
-                    fontWeight: 600,
-                    textDecoration: 'none',
-                  }}
-                  target="_blank"
-                >
-                  Run in Workspace
-                </a>
                 <pre>{examples}</pre>
                 <p>
-                  Instantly run the code above in your browser using{' '}
-                  <a
-                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
-                    target="_blank"
-                  >
+                  Run the code above in your browser using{' '}
+                  <a href={`https://datacamp.com/workspace`} target="_blank">
                     DataCamp Workspace
                   </a>
                 </p>


### PR DESCRIPTION
Removed button to run in workspace and now link below example directs to landing page of workspace. 