### PR TITLE
feat: remove the workspace button when accessing on mobile/ipad

### DIFF
--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -158,7 +158,7 @@ export default function TopicPage({ topicData }: Props) {
                 <p>
                   Run the code above in your browser using{' '}
                   <a
-                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                     target="_blank"
                   >
                     DataCamp Workspace

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -151,7 +151,7 @@ export default function TopicPage({ topicData }: Props) {
                     }}
                     target="_blank"
                   >
-                    Run in Workspace
+                    Use this code
                   </a>
                 )}
                 <pre>{examples}</pre>

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -139,22 +139,24 @@ export default function TopicPage({ topicData }: Props) {
             <section>
               <div className="relative">
                 <h2>Examples</h2>
-                <a
-                  className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                  href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
-                  style={{
-                    background: 'rgba(3, 239, 98)',
-                    color: '#1f2937',
-                    fontWeight: 600,
-                    textDecoration: 'none',
-                  }}
-                  target="_blank"
-                >
-                  Run in Workspace
-                </a>
+                {navigator.maxTouchPoints < 1 && (
+                  <a
+                    className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
+                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    style={{
+                      background: 'rgba(3, 239, 98)',
+                      color: '#1f2937',
+                      fontWeight: 600,
+                      textDecoration: 'none',
+                    }}
+                    target="_blank"
+                  >
+                    Run in Workspace
+                  </a>
+                )}
                 <pre>{examples}</pre>
                 <p>
-                  Instantly run the code above in your browser using{' '}
+                  Run the code above in your browser using{' '}
                   <a
                     href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                     target="_blank"

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -151,7 +151,7 @@ export default function TopicPage({ topicData }: Props) {
                     }}
                     target="_blank"
                   >
-                    Use this code
+                    Run this code
                   </a>
                 )}
                 <pre>{examples}</pre>

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -142,7 +142,7 @@ export default function TopicPage({ topicData }: Props) {
                 {navigator.maxTouchPoints < 1 && (
                   <a
                     className="absolute p-2 text-sm rounded-md top-0	right-0 hover:bg-green-400 md:p-3 md:text-base md:top-16 md:right-2.5"
-                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&title=${name}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
+                    href={`https://app.datacamp.com/workspace/new?_tag=rdocs&rdocsPath=${rdocsPath}&utm_source=r-docs&utm_medium=docs&utm_term=${topic}&utm_content=run_example_in_workspace`}
                     style={{
                       background: 'rgba(3, 239, 98)',
                       color: '#1f2937',


### PR DESCRIPTION
Remove the `Run in Workspace` button when accessing RDocs on a mobile/ipad device. 

Text on button needs to be confirmed

Note : userAgent is flakey and [recommendation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent) is to use maxTouchpoints. 