### PR TITLE
fix: broken crosslinks (#81, #74)

### DIFF
--- a/pages/link/[topic].tsx
+++ b/pages/link/[topic].tsx
@@ -1,4 +1,5 @@
 import { GetServerSideProps } from 'next';
+
 import { API_URL } from '../../lib/utils';
 
 export default function genericLinkPage() {
@@ -6,12 +7,23 @@ export default function genericLinkPage() {
 }
 
 export const getServerSideProps: GetServerSideProps = async ({
-  params: { topic },
-  query: { package: packageName, version },
+  params,
+  query,
 }) => {
+  let topic = Array.isArray(params.topic) ? params.topic[0] : params.topic;
+  let packageName = Array.isArray(query.package)
+    ? query.package[0]
+    : query.package;
+
+  topic = topic.replace(/\(\)$/, '');
+
+  if (topic.includes('::')) {
+    [packageName, topic] = topic.split('::');
+  }
+
   try {
     const res = await fetch(
-      `${API_URL}/link/${topic}?package=${packageName}&version=${version}`,
+      `${API_URL}/link/${topic}?package=${packageName}&version=${query.version}`,
     );
 
     return {


### PR DESCRIPTION
Some of the links are formatted as `function_name()` or `library::function_name()` instead of just `function_name`. This is the convention in the tidyverse's docs.

This change simply removes the brackets and splits the library and function names.

Link to `tidyselect::vars_pull()` from tidyr:

Before: `/link/tidyselect::vars_pull()?package=tidyr`
After: `/link/vars_pull?package=tidyselect`

More info in #81.