### PR TITLE
[CT-3408] Fix workspace button styling

### DIFF
--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -157,6 +157,9 @@ export default function TopicPage({ topicData }: Props) {
                     color: '#1f2937',
                     fontWeight: 600,
                     textDecoration: 'none',
+                    ...(examples.split(/\r\n|\r|\n/)?.length <= 2
+                      ? { padding: '4px 8px' }
+                      : {}),
                   }}
                   target="_blank"
                 >


### PR DESCRIPTION
When the example is only 1 line, resize the button to fit the cell.

**Before:**
![image](https://user-images.githubusercontent.com/38893718/171739969-4e949d4c-d4d1-48d0-ad27-307c61fd085c.png)

**After:**
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/38893718/171739924-d8b54a46-b5a3-4ac2-8d83-4f17e1d60752.png">
