### PR TITLE
[CT-3571] Fix rendering of arguments for upcoming API change

### DIFF
--- a/components/Html.tsx
+++ b/components/Html.tsx
@@ -1,7 +1,13 @@
 type Props = {
   children: string;
+  className?: string;
 };
 
-export default function Html({ children }: Props) {
-  return <span dangerouslySetInnerHTML={{ __html: children }} />;
+export default function Html({ children, className }: Props) {
+  return (
+    <span
+      className={className}
+      dangerouslySetInnerHTML={{ __html: children }}
+    />
+  );
 }

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useMemo } from 'react';
 import ReactGA from 'react-ga';
 
 import Html from '../../../../../../components/Html';
@@ -61,6 +62,15 @@ export default function TopicPage({ topicData }: Props) {
     });
   };
 
+  const showLegacyArguments = useMemo(() => {
+    return (
+      args &&
+      sections.filter((section) =>
+        section.name?.toLowerCase()?.includes('argument'),
+      )?.length < 1
+    );
+  }, [args, sections]);
+
   return (
     <Layout
       canonicalLink={canonicalLink}
@@ -95,7 +105,7 @@ export default function TopicPage({ topicData }: Props) {
               </pre>
             </section>
           )}
-          {args && (
+          {showLegacyArguments && (
             <section>
               <h2>Arguments</h2>
               {args.map((arg) => (
@@ -118,12 +128,22 @@ export default function TopicPage({ topicData }: Props) {
           )}
           {sections && sections.length > 0 && (
             <section>
-              {sections.map((section) => (
-                <div key={section.name}>
-                  <h2>{section.name}</h2>
-                  <Html>{section.description}</Html>
-                </div>
-              ))}
+              {sections.map((section) => {
+                if (section.name?.toLowerCase()?.includes('argument')) {
+                  return (
+                    <div key={section.name}>
+                      <h2>{section.name}</h2>
+                      <Html className="arguments">{section.description}</Html>
+                    </div>
+                  );
+                }
+                return (
+                  <div key={section.name}>
+                    <h2>{section.name}</h2>
+                    <Html>{section.description}</Html>
+                  </div>
+                );
+              })}
             </section>
           )}
           {details && (

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -129,18 +129,14 @@ export default function TopicPage({ topicData }: Props) {
           {sections && sections.length > 0 && (
             <section>
               {sections.map((section) => {
-                if (section.name?.toLowerCase()?.includes('argument')) {
-                  return (
-                    <div key={section.name}>
-                      <h2>{section.name}</h2>
-                      <Html className="arguments">{section.description}</Html>
-                    </div>
-                  );
-                }
                 return (
                   <div key={section.name}>
                     <h2>{section.name}</h2>
-                    <Html>{section.description}</Html>
+                    {section.name?.toLowerCase()?.includes('argument') ? (
+                      <Html className="arguments">{section.description}</Html>
+                    ) : (
+                      <Html>{section.description}</Html>
+                    )}
                   </div>
                 );
               })}

--- a/styles/index.css
+++ b/styles/index.css
@@ -25,3 +25,46 @@
     @apply w-full;
   }
 }
+
+.arguments dl {
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  margin: 0;
+}
+
+.arguments dt {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+  font-weight: 600;
+  float: left;
+  width: 20%;
+  padding: 0;
+  margin: 0;
+}
+
+.arguments dd {
+  display: block;
+  margin-left: 40px;
+  float: left;
+  width: 80%;
+  padding: 0;
+  margin: 0;
+}
+
+.arguments dd p {
+  margin-top: 0;
+}
+
+@media (max-width: 600px) {
+  .arguments dt {
+    float: none;
+    width: 100%;
+  }
+
+  .arguments dd {
+    float: none;
+    width: 100%;
+    margin: 0.5rem 0 1.5rem 0;
+  }
+}


### PR DESCRIPTION
Fixes [CT-3571](https://datacamp.atlassian.net/browse/CT-3571)

Arguments are now part of `sections` instead of `args`. This update should work both for new packages that use `sections` and old packages that use `args`.

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/38893718/173706647-fea9f48e-9cb7-4b49-b395-a028c0d34ef2.png">

<img width="364" alt="image" src="https://user-images.githubusercontent.com/38893718/173706627-2f9f6d9d-f76d-4924-9c5a-ed03a68747f0.png">
