### PR TITLE
[CTfix/add mathJax property and fix section styles

### DIFF
--- a/components/Html.tsx
+++ b/components/Html.tsx
@@ -8,13 +8,12 @@ type Props = {
 export default function Html({ children, className }: Props) {
   return (
     <MathJaxContext>
-      <MathJax>
+      <MathJax hideUntilTypeset="first">
         <span
           className={className}
           dangerouslySetInnerHTML={{ __html: children }}
         />
       </MathJax>
     </MathJaxContext>
-    
   );
 }

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -123,7 +123,7 @@ export default function TopicPage({ topicData }: Props) {
           {value && (
             <section>
               <h2>Value</h2>
-              <Html>{value}</Html>
+              <Html className="list-view">{value}</Html>
             </section>
           )}
           {sections && sections.length > 0 && (
@@ -144,7 +144,7 @@ export default function TopicPage({ topicData }: Props) {
           {details && (
             <section>
               <h2>Details</h2>
-              <Html>{details}</Html>
+              <Html className="list-view">{details}</Html>
             </section>
           )}
           {references && (


### PR DESCRIPTION
[TICKET](https://datacamp.atlassian.net/browse/CT-3637?atlOrigin=eyJpIjoiYzBhMDg5YmExMDNmNDg5ZjgwZDEzZjdlMTJiYjM0ZjciLCJwIjoiaiJ9)
- The latex would render successfully but fail if the page was refreshed. I [asked the developer](https://github.com/fast-reflexes/better-react-mathjax/issues/18) of the package and they suggested an adjustment that I could make to fix it (in the [API section of the readme](https://github.com/fast-reflexes/better-react-mathjax)). 
- There are also dt, dd and dl elements in the 'value' section that need to have the styling applied so I adjusted that too, here are some comparisons:
<img width="1792" alt="Screenshot 2022-06-28 at 15 29 19" src="https://user-images.githubusercontent.com/107868502/176204909-7f11577c-80d5-4ef2-af93-ae8243bf6b27.png">
<img width="1792" alt="Screenshot 2022-06-28 at 15 30 45" src="https://user-images.githubusercontent.com/107868502/176205184-1587f959-1bf5-44a7-8ec4-814ce8f6bf27.png">

 