### PR TITLE
[CT-3782] chore: replace readme not available message

### DIFF
--- a/components/PackageReadMePlaceholder.tsx
+++ b/components/PackageReadMePlaceholder.tsx
@@ -1,15 +1,13 @@
 import Html from './Html';
 
 type Props = {
-    data: {
-        packageName: string,
-        version: string,
-        title: string,
-        description: string
-    }
+      packageName: string,
+      version: string,
+      title: string,
+      description: string
 }
 
-export default function PackageReadMePlaceholder({data}: Props) {
+export default function PackageReadMePlaceholder(data: Props) {
   const {
     packageName,
     version,

--- a/components/PackageReadMePlaceholder.tsx
+++ b/components/PackageReadMePlaceholder.tsx
@@ -1,0 +1,53 @@
+import Html from './Html';
+
+type Props = {
+    data: {
+        packageName: string,
+        version: string,
+        title: string,
+        description: string
+    }
+}
+
+export default function PackageReadMePlaceholder({data}: Props) {
+  const {
+    packageName,
+    version,
+    title,
+    description
+  } = data;
+
+  return (
+    <div
+    >
+      <div className="max-w-screen-lg mt-8 md:mt-12">
+        <div className="mt-2 prose-sm prose sm:prose max-w-none sm:max-w-none">
+          <header>
+            <h1>
+              <Html>{`${packageName} (version ${version})`}</Html>
+            </h1>
+          </header>
+          {
+            title 
+            &&
+            (
+            <section>
+                <h2 className="text-xl text-gray-500">{title}</h2>
+            </section>
+            )
+          }
+          {
+            description 
+            && 
+            (
+            <section>
+              <h2>Description</h2>
+              <Html>{description}</Html>
+            </section>
+            )
+          }
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/packages/[package]/versions/[version].tsx
+++ b/pages/packages/[package]/versions/[version].tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import Layout from '../../../../components/Layout';
 import PackageFunctionList from '../../../../components/PackageFunctionList';
 import PackageReadme from '../../../../components/PackageReadme';
+import PackageReadMePlaceholder from '../../../../components/PackageReadMePlaceholder';
 import PackageSidebar from '../../../../components/PackageSidebar';
 import { getMonthlyDownloads } from '../../../../lib/downloads';
 import {
@@ -112,7 +113,20 @@ export default function PackageVersionPage({
                 </Link>
               </div>
             )}
+            {
+            metadata.readmemd 
+            ?
             <PackageReadme readme={metadata.readmemd} />
+            :
+            <PackageReadMePlaceholder
+              data={{
+                packageName: metadata.package_name,
+                version: metadata.version,
+                title: metadata.title,
+                description: metadata.description
+              }}
+              />
+            }
           </div>
           <div className="w-full pt-8 border-t lg:border-t-0 lg:w-1/3 lg:pt-0 lg:pl-8 lg:border-l">
             <PackageSidebar

--- a/pages/packages/[package]/versions/[version].tsx
+++ b/pages/packages/[package]/versions/[version].tsx
@@ -119,12 +119,10 @@ export default function PackageVersionPage({
             <PackageReadme readme={metadata.readmemd} />
             :
             <PackageReadMePlaceholder
-              data={{
-                packageName: metadata.package_name,
-                version: metadata.version,
-                title: metadata.title,
-                description: metadata.description
-              }}
+                packageName = {metadata.package_name}
+                version = {metadata.version}
+                title = {metadata.title}
+                description = {metadata.description}
               />
             }
           </div>


### PR DESCRIPTION
[TICKET](https://datacamp.atlassian.net/browse/CT-3782?atlOrigin=eyJpIjoiZWZhMDZkNGQ2YTE0NGU3NzllNjA2OGNiZTQ1MzMxNzAiLCJwIjoiaiJ9)

[ISSUE](https://github.com/datacamp/rdocumentation-2.0/issues/107#issue-1249366451)

Removed "readme not available" message and replaced with package metadata.

Before:
<img width="1792" alt="Screenshot 2022-07-05 at 15 11 04" src="https://user-images.githubusercontent.com/107868502/177350114-be4fb931-a22b-4500-b5b2-d383a44d42e8.png">
After:
<img width="1792" alt="Screenshot 2022-07-05 at 15 11 07" src="https://user-images.githubusercontent.com/107868502/177350168-2940d127-d217-4447-8062-3d4af89a0e4b.png">

Before:
<img width="1792" alt="Screenshot 2022-07-05 at 15 11 11" src="https://user-images.githubusercontent.com/107868502/177350257-def9ab1c-77c5-4d41-9a87-14ab6e96f6c2.png">
After:
<img width="1792" alt="Screenshot 2022-07-05 at 15 11 14" src="https://user-images.githubusercontent.com/107868502/177350306-932d9695-d5cc-44ad-b4c8-4effb359a502.png">


Replace the readme not available message to improve user experience.