### PR TITLE
fix: hide functions list if package has no functions

### DIFF
--- a/pages/packages/[package]/versions/[version].tsx
+++ b/pages/packages/[package]/versions/[version].tsx
@@ -133,11 +133,15 @@ export default function PackageVersionPage({
           </div>
         </div>
         <div className="w-full pt-8 mt-12 border-t lg:pt-0 lg:border-t-0 max-w-none">
-          <PackageFunctionList
-            functions={metadata.topics}
-            packageName={metadata.package_name}
-            packageVersion={metadata.version}
-          />
+          {
+            metadata.topics.length > 0
+            &&
+            <PackageFunctionList
+              functions={metadata.topics}
+              packageName={metadata.package_name}
+              packageVersion={metadata.version}
+            />
+          }
         </div>
       </div>
     </Layout>
@@ -153,6 +157,8 @@ export const getServerSideProps: GetServerSideProps = async ({
       `${API_URL}/api/packages/${packageName}/versions/${version}`,
     );
     const metadata = await res.json();
+
+    console.log({topics: metadata.topics})
 
     // create an array of all package versions
     const versionsArray = metadata.package.versions.map((v) => v.version);

--- a/pages/packages/[package]/versions/[version].tsx
+++ b/pages/packages/[package]/versions/[version].tsx
@@ -134,7 +134,7 @@ export default function PackageVersionPage({
         </div>
         <div className="w-full pt-8 mt-12 border-t lg:pt-0 lg:border-t-0 max-w-none">
           {
-            metadata.topics.length > 0
+            metadata.topics?.length > 0
             &&
             <PackageFunctionList
               functions={metadata.topics}
@@ -157,8 +157,6 @@ export const getServerSideProps: GetServerSideProps = async ({
       `${API_URL}/api/packages/${packageName}/versions/${version}`,
     );
     const metadata = await res.json();
-
-    console.log({topics: metadata.topics})
 
     // create an array of all package versions
     const versionsArray = metadata.package.versions.map((v) => v.version);


### PR DESCRIPTION
Small ui fix to remove the functions section if there aren't any functions in the package. I think it looks cleaner. (readme will be fixed once merged)

Before:
<img width="1792" alt="Screenshot 2022-07-07 at 13 29 21" src="https://user-images.githubusercontent.com/107868502/177773918-0792158e-52e2-4080-b13e-53b259c3ec16.png">
After: 
<img width="1792" alt="Screenshot 2022-07-07 at 13 29 33" src="https://user-images.githubusercontent.com/107868502/177773939-266fd770-3d8b-41fe-b774-045de3f50872.png">

