### PR TITLE
[CT-3781] fix: empty search results and constant loading

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -60,7 +60,7 @@ export default function SearchResults() {
           },
         );
         const resFunctions = await fetch(
-          `${API_URL}/search_functions?q=${searchTerm}&page=${pageNumber}&latest=1`,
+          `${API_URL}/search_functions?q=${searchTerm}&package=${searchTerm}&page=${pageNumber}&latest=1`,
           {
             headers: {
               Accept: 'application/json',
@@ -73,6 +73,7 @@ export default function SearchResults() {
         setFunctionResults(functions);
         setIsLoading(false);
       } catch (error) {
+        setIsLoading(false);
         console.log(error);
       }
     }


### PR DESCRIPTION
[TICKET](https://datacamp.atlassian.net/browse/CT-3781?atlOrigin=eyJpIjoiNjIxMTU1Y2VhYWY0NGYxOWE2MmVkMjg5ZmI1NTMxMjIiLCJwIjoiaiJ9)

ISSUES: #110 #68 

Changes made: 
- Fix the /search_functions api call. Without the packages parameter, the controller would throw an error for certain query parameters (see issues).
- Fix the constant loading state when results are not available, I think its better to just say no results.

The below examples are related to the issues.

Before:
<img width="1792" alt="Screenshot 2022-07-08 at 12 01 16" src="https://user-images.githubusercontent.com/107868502/177980442-2fa29f6f-8b10-43dd-800a-c1362d6f3bd9.png">
<img width="587" alt="Screenshot 2022-07-08 at 12 02 48" src="https://user-images.githubusercontent.com/107868502/177980504-24a97240-d014-4d44-af29-f3b067d3b385.png">
<img width="1792" alt="Screenshot 2022-07-08 at 12 01 29" src="https://user-images.githubusercontent.com/107868502/177980515-57080bb7-dc60-415d-9763-6fa7cc66b24c.png">
<img width="567" alt="Screenshot 2022-07-08 at 12 02 14" src="https://user-images.githubusercontent.com/107868502/177980541-25bea52e-459b-49ff-8741-b09096f05eef.png">

After: 
<img width="1792" alt="Screenshot 2022-07-08 at 12 03 12" src="https://user-images.githubusercontent.com/107868502/177980567-2e53ac37-99f0-47df-a694-2f7f5c5e16f6.png">
<img width="639" alt="Screenshot 2022-07-08 at 12 04 00" src="https://user-images.githubusercontent.com/107868502/177980602-426d107a-2701-4e47-b4cc-9f53ffb7aeea.png">
<img width="1792" alt="Screenshot 2022-07-08 at 12 03 19" src="https://user-images.githubusercontent.com/107868502/177980617-c3e3c393-7513-4e38-9afd-f1420d8fb14c.png">
<img width="639" alt="Screenshot 2022-07-08 at 12 04 00" src="https://user-images.githubusercontent.com/107868502/177980641-6ec6f17c-09f1-44c9-9a8a-7c5086a23b5f.png">

