### PR TITLE
[CT-3469] Refactor: add autocomplete to navbar, fix redirect

### DIFF
--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -4,19 +4,30 @@ import { useEffect, useState } from "react";
 import { API_URL } from "../lib/utils";
 
 type Props = {
-    searchInput: string
+    searchInput: string,
+    onSearch: () => void,
 };
 
-export default function AutoComplete({ searchInput }: Props) {
-
+export default function AutoComplete({ searchInput, onSearch }: Props) {
   const [packageSuggestions, setPackageSuggestions] = useState([]);
   const [topicSuggestions, setTopicSuggestions] = useState([]);
 
     function onClick(query, type) {
-      if (type==="topic") {
-        router.push(`/packages/${encodeURIComponent(query?.fields?.package_name)}/versions/${encodeURIComponent(query?.fields?.version)}/topics/${encodeURIComponent(query?.fields?.name)}`);
-      } else {
-        router.push(`/search?q=${encodeURIComponent(query)}`);
+      switch (type) {
+        case "topic":
+          router.push(`/packages/${encodeURIComponent(query?.fields?.package_name)}/versions/${encodeURIComponent(query?.fields?.version)}/topics/${encodeURIComponent(query?.fields?.name)}`);
+          onSearch();
+          break
+        case "package":
+          router.push(`/search?q=${encodeURIComponent(query)}`);
+          onSearch();
+          break
+        case "search":
+          router.push(`/search?q=${encodeURIComponent(query)}`);
+          onSearch();
+          break
+        default:
+          break
       }
     };
 
@@ -89,7 +100,7 @@ export default function AutoComplete({ searchInput }: Props) {
                       onClick={()=>onClick(p?.fields?.package_name, "package")}
                       className="flex items-center px-4 py-2 cursor-pointer hover:bg-dc-beige200 hover:opacity-0.5"
                       >
-                        <Paragraph className="pl-2 text-lg">{p?.fields?.package_name}</Paragraph>
+                        <Paragraph className="pl-2 sm:text-lg">{p?.fields?.package_name}</Paragraph>
                       </li>
                     )
                 })}
@@ -112,13 +123,13 @@ export default function AutoComplete({ searchInput }: Props) {
                       <li
                       key={t?.fields?.package_name+t?.fields?.name}
                       onClick={()=>onClick(t, "topic")}
-                      className="flex items-center px-4 py-2 cursor-pointer hover:bg-dc-beige200 hover:opacity-0.5"
+                      className="flex flex-wrap items-center px-4 py-2 cursor-pointer hover:bg-dc-beige200 hover:opacity-0.5"
                       >
                         <div>
-                          <Paragraph className="px-2 text-lg">{`${t?.fields?.name}`}</Paragraph>
+                          <Paragraph className="pl-2 pr-1 sm:pr-2 sm:text-lg">{`${t?.fields?.name}`}</Paragraph>
                         </div>
                         <div>
-                          <Paragraph className="text-lg text-dc-red">{`(${t?.fields?.package_name})`}</Paragraph>
+                          <Paragraph className="sm:text-lg">{`(${t?.fields?.package_name})`}</Paragraph>
                         </div>
                       </li>
                     )

--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -12,8 +12,12 @@ export default function AutoComplete({ searchInput }: Props) {
   const [packageSuggestions, setPackageSuggestions] = useState([]);
   const [topicSuggestions, setTopicSuggestions] = useState([]);
 
-    function onClick(query) {
-      router.push(`/search?q=${encodeURIComponent(query)}`);
+    function onClick(query, type) {
+      if (type==="topic") {
+        router.push(`/packages/${encodeURIComponent(query?.fields?.package_name)}/versions/${encodeURIComponent(query?.fields?.version)}/topics/${encodeURIComponent(query?.fields?.name)}`);
+      } else {
+        router.push(`/search?q=${encodeURIComponent(query)}`);
+      }
     };
 
     async function autoComplete(query) {
@@ -61,7 +65,7 @@ export default function AutoComplete({ searchInput }: Props) {
             searchInput
             &&
             <div
-            onClick={()=>onClick(searchInput)}
+            onClick={()=>onClick(searchInput, "search")}
             className="flex items-center px-4 py-4 cursor-pointer hover:bg-dc-beige200 hover:opacity-0.5"
             >
               <Paragraph className="pl-2 py-2">{`View results for "${searchInput}"`}</Paragraph>
@@ -82,7 +86,7 @@ export default function AutoComplete({ searchInput }: Props) {
                     return (
                       <li
                       key={p?.fields?.package_name}
-                      onClick={()=>onClick(p?.fields?.package_name)}
+                      onClick={()=>onClick(p?.fields?.package_name, "package")}
                       className="flex items-center px-4 py-2 cursor-pointer hover:bg-dc-beige200 hover:opacity-0.5"
                       >
                         <Paragraph className="pl-2 text-lg">{p?.fields?.package_name}</Paragraph>
@@ -107,7 +111,7 @@ export default function AutoComplete({ searchInput }: Props) {
                     return (
                       <li
                       key={t?.fields?.package_name+t?.fields?.name}
-                      onClick={()=>onClick(t?.fields?.name)}
+                      onClick={()=>onClick(t, "topic")}
                       className="flex items-center px-4 py-2 cursor-pointer hover:bg-dc-beige200 hover:opacity-0.5"
                       >
                         <div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -6,6 +6,7 @@ import { useContext, useState } from 'react';
 import { FaGithub } from 'react-icons/fa';
 
 import { ThemeContext } from '../pages/_app';
+import AutoComplete from './Autocomplete';
 
 export default function Navbar() {
   const [searchInput, setSearchInput] = useState('');
@@ -58,23 +59,35 @@ export default function Navbar() {
 
       {/* show search bar if relevant */}
       {showSearch && (
-        <form onSubmit={onSubmitSearch}>
-          <div className="dc-input">
-            <label className="sr-only" htmlFor="searchBarNav">
-              Search all packages and functions
-            </label>
-            <Input
-              className="w-full md:w-80 lg:w-96"
-              id="searchBarNav"
-              name="searchBarNav"
-              onChange={setSearchInput}
-              placeholder="Search all packages and functions"
-              size="small"
-              type="search"
-              value={searchInput}
-            />
+        <div className="flex flex-col max-h-4 max-w-4xl">
+          <form onSubmit={onSubmitSearch}>
+            <div className="dc-input">
+              <label className="sr-only" htmlFor="searchBarNav">
+                Search all packages and functions
+              </label>
+              <Input
+                className="w-full"
+                id="searchBarNav"
+                name="searchBarNav"
+                onChange={setSearchInput}
+                placeholder="Search all packages and functions"
+                size="small"
+                type="search"
+                value={searchInput}
+              />
+            </div>
+          </form>
+          <div className="md:w-80 lg:w-96">
+            {
+              searchInput 
+              &&
+              <AutoComplete
+              onSearch={()=>setSearchInput("")}
+              searchInput={searchInput}
+              />
+            }
           </div>
-        </form>
+        </div>
       )}
     </header>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -38,9 +38,14 @@ export default function HomePage({ packageCount }: { packageCount?: number }) {
             value={searchInput}
           />
         </form>
-        <AutoComplete
+        {
+          searchInput 
+          &&
+          <AutoComplete
+          onSearch={()=>setSearchInput("")}
           searchInput={searchInput}
-        />
+          />
+        }
       </div>
     </Layout>
   );


### PR DESCRIPTION
## [Ticket](https://datacamp.atlassian.net/browse/CT-3469?atlOrigin=eyJpIjoiOWM2OGYyNWFjMGQ4NDgxYmJlZjgyM2I4MDc2ODVhYjgiLCJwIjoiaiJ9)

Making function suggestions redirect straight to topic page instead of global search results page.

Was going to do the same for packages suggestions, however there are some broken links so a risk that the suggestion will link to a "oops, page not found".

### Changes

- OnSearch function ensures that the searchbar clears and the autocomplete disappears once a search has been made. (This is has more of a ui effect on the navbar search as the autocomplete would cover search results otherwise).

- I have also wrapped autosuggestion text to ensure there is no overflow.

- I have changed the function redirect to point to specific topic pages and placed in a switch statement.

### Pictures
Before (Desktop):
<img width="1792" alt="Screenshot 2022-07-12 at 16 02 31" src="https://user-images.githubusercontent.com/107868502/178527063-437447d0-ed24-488c-8bc3-b749810813ce.png">

After (Desktop):
<img width="1792" alt="Screenshot 2022-07-12 at 16 06 11" src="https://user-images.githubusercontent.com/107868502/178526782-996a0475-f0ad-40ec-ab2f-e31665c17985.png">

Before (Mobile):
<img width="1792" alt="Screenshot 2022-07-12 at 16 03 38" src="https://user-images.githubusercontent.com/107868502/178526860-9ba1b6ea-992e-4ae6-9ac8-baf39eee4dfa.png">

After (Mobile):
<img width="1792" alt="Screenshot 2022-07-12 at 16 03 26" src="https://user-images.githubusercontent.com/107868502/178526934-4258f509-b10e-4d6a-a381-d4d781c9f145.png">

