### PR TITLE
[FP-769] Migrate to GA4

### DIFF
--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,8 +1,1 @@
-export const GA_TRACKING_ID = 'UA-41577880-1';
-
-// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url) => {
-  window.gtag('config', GA_TRACKING_ID, {
-    page_path: url,
-  });
-};
+export const GA4_TRACKING_ID = 'G-NL07LSD2L8';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postcss": "^8.1.10",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-ga": "^3.3.0",
+    "react-ga4": "^2.1.0",
     "react-icons": "^4.1.0",
     "react-markdown": "^5.0.3",
     "react-syntax-highlighter": "^15.5.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,9 +2,8 @@ import '../styles/index.css';
 
 import { GlobalFontFaces } from '@datacamp/waffles-text';
 import type { AppProps } from 'next/app';
-import { useRouter } from 'next/router';
 import { createContext, useEffect, useState } from 'react';
-import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 
 import * as gtag from '../lib/gtag';
 
@@ -26,7 +25,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   // if we're client-side, check local storage on mount
   useEffect(() => {
-    ReactGA.initialize(gtag.GA_TRACKING_ID);
+    ReactGA4.initialize(gtag.GA4_TRACKING_ID);
 
     if (window) {
       const savedTheme = localStorage.getItem('theme');
@@ -39,17 +38,6 @@ export default function MyApp({ Component, pageProps }: AppProps) {
     document.querySelector('html').classList.toggle('dark', theme === 'dark');
     if (window) localStorage.setItem('theme', theme);
   }, [theme]);
-
-  const router = useRouter();
-  useEffect(() => {
-    const handleRouteChange = (url) => {
-      gtag.pageview(url);
-    };
-    router.events.on('routeChangeComplete', handleRouteChange);
-    return () => {
-      router.events.off('routeChangeComplete', handleRouteChange);
-    };
-  }, [router.events]);
 
   return (
     <>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,8 +7,6 @@ import Document, {
   NextScript,
 } from 'next/document';
 
-import { GA_TRACKING_ID } from '../lib/gtag';
-
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -25,18 +23,9 @@ class MyDocument extends Document {
             name="google-site-verification"
           />
           <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
-          />
-          <script
             dangerouslySetInnerHTML={{
               __html: `
               window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
-              gtag('config', '${GA_TRACKING_ID}', {
-                page_path: window.location.pathname,
-              });
             `,
             }}
           />

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -2,7 +2,7 @@ import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
-import ReactGA from 'react-ga';
+import ReactGA4 from 'react-ga4';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import atomOneDark from 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark';
 
@@ -57,7 +57,7 @@ export default function TopicPage({ topicData }: Props) {
     `packages/${packageName}/versions/${packageVersion}/topics/${topic}`,
   );
   const registerClicks = (label) => {
-    ReactGA.event({
+    ReactGA4.event({
       action: 'Click',
       category: 'Run in workspace',
       label,
@@ -131,8 +131,8 @@ export default function TopicPage({ topicData }: Props) {
           {sections && sections.length > 0 && (
             <section>
               {sections.map((section) => {
-                if (section.description.length<1) {
-                  return
+                if (section.description.length < 1) {
+                  return;
                 }
                 return (
                   <div key={section.name}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4233,10 +4233,10 @@ react-dom@^17.0.1:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-ga@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
-  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
 react-icons@^4.1.0:
   version "4.4.0"


### PR DESCRIPTION
This PR should migrate from Google Analytics UA to GA4, [epic link](https://datacamp.atlassian.net/browse/FP-740) is here with all the work being done for this migration:

- Replace react-ga with react-ga4
- Use the new `G-{id}` web data stream id
- Remove the manual SPA page view events that were hooked into the route
- Remove a duped injection of the gtag script in `_document.tsx` (react-ga4 injects this already)
- Update the "Run in workspace" event call to use the GA4 format/function

Based off the research I've done, this should work out of the box with Next and GA4 thanks to GA4's "enhanced measurement" in data streams. All we need to do is is enable "Page changes based on history browser events" in the web data stream settings. I won't do that until we're QA'ing on Staging though as it will record double page views in production due to the old code still being there.

<img width="480" alt="Screen Shot 2023-06-16 at 12 07 15" src="https://github.com/datacamp/rdocumentation-2.0/assets/678575/e275e7ca-6e1c-4d71-a917-2639d4abd195">

Note: I did consider migrating GA to Google Tag Manager, but GTM isn't currently implemented in rdocs 2.0 but we could get that on the roadmap if needed later in the year.

Plan:

- [x] Run locally and QA locally
- [x] Review and merge
- [ ] QA on staging (loading, page views, realtime report, run in workspace event)
- [ ] Release to production
- [ ] QA production

https://datacamp.atlassian.net/browse/FP-769