### PR TITLE
[COMM-5586] Remove package param from functions search query to fix error with functions not loading

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -60,7 +60,7 @@ export default function SearchResults() {
           },
         );
         const resFunctions = await fetch(
-          `${API_URL}/search_functions?q=${searchTerm}&package=${searchTerm}&page=${pageNumber}&latest=1`,
+          `${API_URL}/search_functions?q=${searchTerm}&page=${pageNumber}&latest=1`,
           {
             headers: {
               Accept: 'application/json',


### PR DESCRIPTION
Ticket: https://datacamp.atlassian.net/browse/COMM-5586

Note: This is only part of the solution. For some functions, the API call errors with a 500. We will need to fix that as well.

Before:
<img width="600" alt="image" src="https://github.com/datacamp/rdocumentation-2.0/assets/38893718/7b3254d1-2e3f-47af-bc37-e68acd4fd742">

After:
<img width="600" alt="image" src="https://github.com/datacamp/rdocumentation-2.0/assets/38893718/707ff2c3-6f4e-46d6-8f4f-9bb20ba93aee">
