### PR TITLE
[OGE-1878] add course ads and apply styling feedback

### DIFF
--- a/components/CourseAds.tsx
+++ b/components/CourseAds.tsx
@@ -1,0 +1,73 @@
+/** @jsxImportSource @emotion/react */
+import { RLogomark } from '@datacamp/waffles/asset';
+import { Card } from '@datacamp/waffles/card';
+import { Link } from '@datacamp/waffles/link';
+import { tokens } from '@datacamp/waffles/tokens';
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div({
+  display: 'grid',
+  gridGap: tokens.spacing.medium,
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  marginBottom: tokens.spacing.medium,
+});
+
+const cards = [
+  {
+    description:
+      'Level-up your R programming skills! Learn how to work with common data structures, optimize code, and write your own functions.',
+    link: 'https://www.datacamp.com/tracks/r-programming-fundamentals',
+    title: 'R Fundamentals',
+  },
+  {
+    description:
+      'Work with big data in R via parallel programming, interfacing with Spark, writing scalable & efficient R code, and learn ways to visualize big data.',
+    link: 'https://www.datacamp.com/tracks/big-data-with-r',
+    title: 'Big Data with R',
+  },
+  {
+    description:
+      'A machine learning scientist researches new approaches and builds machine learning models.',
+    link: 'https://www.datacamp.com/tracks/machine-learning-scientist-with-r',
+    title: 'Machine Learning with R',
+  },
+];
+
+function CourseAds() {
+  return (
+    <Wrapper>
+      {cards.map(({ description, link, title }) => (
+        <Card
+          css={{
+            '&:active, &:focus, &:hover': {
+              cursor: 'pointer',
+            },
+          }}
+          headstone={<Card.HeadstoneAvatar content={<RLogomark />} />}
+          key={title}
+          onClick={() => {
+            // TODO: use router
+            window.location.href = link;
+          }}
+        >
+          <Card.Header>
+            <Link
+              css={{
+                '&:active, &:focus, &:hover': {
+                  cursor: 'pointer',
+                },
+              }}
+              href={link}
+            >
+              {title}
+            </Link>
+          </Card.Header>
+
+          <Card.Body>{description}</Card.Body>
+        </Card>
+      ))}
+    </Wrapper>
+  );
+}
+
+export default CourseAds;

--- a/components/CourseAds.tsx
+++ b/components/CourseAds.tsx
@@ -49,8 +49,13 @@ function CourseAds() {
   }
 
   return (
-    <section>
-      <Heading css={{ marginBottom: tokens.spacing.medium }}>
+    <section css={{ marginBottom: tokens.spacing.medium }}>
+      <Heading
+        css={{
+          marginBottom: tokens.spacing.large,
+          marginTop: tokens.spacing.small,
+        }}
+      >
         Continue Improving Your R Skills
       </Heading>
       <Wrapper>
@@ -61,6 +66,7 @@ function CourseAds() {
                 cursor: 'pointer',
               },
             }}
+            data-trackid={`course-ads-${title}`}
             key={title}
             onClick={() => router.push(link)}
           >
@@ -76,7 +82,6 @@ function CourseAds() {
                 {title}
               </Link>
             </Card.Header>
-
             <Card.Body>{description}</Card.Body>
           </Card>
         ))}

--- a/components/CourseAds.tsx
+++ b/components/CourseAds.tsx
@@ -1,15 +1,22 @@
 /** @jsxImportSource @emotion/react */
-import { RLogomark } from '@datacamp/waffles/asset';
 import { Card } from '@datacamp/waffles/card';
+import { Heading } from '@datacamp/waffles/heading';
+import { mediaQuery } from '@datacamp/waffles/helpers';
 import { Link } from '@datacamp/waffles/link';
 import { tokens } from '@datacamp/waffles/tokens';
 import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+
+import { useRenderCourseAds } from '../helpers/hooks/useRenderCourseAds';
 
 const Wrapper = styled.div({
   display: 'grid',
   gridGap: tokens.spacing.medium,
-  gridTemplateColumns: 'repeat(3, 1fr)',
+  gridTemplateColumns: '1fr',
   marginBottom: tokens.spacing.medium,
+  [mediaQuery.aboveMedium]: {
+    gridTemplateColumns: 'repeat(3, 1fr)',
+  },
 });
 
 const cards = [
@@ -34,39 +41,47 @@ const cards = [
 ];
 
 function CourseAds() {
-  return (
-    <Wrapper>
-      {cards.map(({ description, link, title }) => (
-        <Card
-          css={{
-            '&:active, &:focus, &:hover': {
-              cursor: 'pointer',
-            },
-          }}
-          headstone={<Card.HeadstoneAvatar content={<RLogomark />} />}
-          key={title}
-          onClick={() => {
-            // TODO: use router
-            window.location.href = link;
-          }}
-        >
-          <Card.Header>
-            <Link
-              css={{
-                '&:active, &:focus, &:hover': {
-                  cursor: 'pointer',
-                },
-              }}
-              href={link}
-            >
-              {title}
-            </Link>
-          </Card.Header>
+  const shouldRender = useRenderCourseAds();
+  const router = useRouter();
 
-          <Card.Body>{description}</Card.Body>
-        </Card>
-      ))}
-    </Wrapper>
+  if (!shouldRender) {
+    return null;
+  }
+
+  return (
+    <section>
+      <Heading css={{ marginBottom: tokens.spacing.medium }}>
+        Continue Improving Your R Skills
+      </Heading>
+      <Wrapper>
+        {cards.map(({ description, link, title }) => (
+          <Card
+            css={{
+              '&:active, &:focus, &:hover': {
+                cursor: 'pointer',
+              },
+            }}
+            key={title}
+            onClick={() => router.push(link)}
+          >
+            <Card.Header>
+              <Link
+                css={{
+                  '&:active, &:focus, &:hover': {
+                    cursor: 'pointer',
+                  },
+                }}
+                href={link}
+              >
+                {title}
+              </Link>
+            </Card.Header>
+
+            <Card.Body>{description}</Card.Body>
+          </Card>
+        ))}
+      </Wrapper>
+    </section>
   );
 }
 

--- a/components/HomePageLinks.tsx
+++ b/components/HomePageLinks.tsx
@@ -78,6 +78,7 @@ export const HomePageLinks = () => {
       <Column>
         <Button
           as="a"
+          data-trackid={'course-link-r-fundamentals'}
           href="https://www.datacamp.com/tracks/r-programming-fundamentals"
           iconRight={<ExternalLink />}
           size={buttonSize}
@@ -90,12 +91,14 @@ export const HomePageLinks = () => {
           </Paragraph>
           <Link
             css={linkStyle}
+            data-trackid={'course-link-free-introduction-to-r'}
             href="https://www.datacamp.com/courses/free-introduction-to-r"
           >
             Introduction to R
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'course-link-data-visualization-with-r'}
             href="https://www.datacamp.com/tracks/data-visualization-with-r"
           >
             Data Visualization with R
@@ -105,18 +108,21 @@ export const HomePageLinks = () => {
           </Paragraph>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-cheat-sheet-getting-started-r'}
             href="https://www.datacamp.com/cheat-sheet/getting-started-r"
           >
             R Basics Cheat Sheet
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-tutorial-linear-regression-r'}
             href="https://www.datacamp.com/tutorial/linear-regression-R"
           >
             Linear Regression in R
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-tutorial-make-histogram-basic-r'}
             href="https://www.datacamp.com/tutorial/make-histogram-basic-r"
           >
             Histograms in R
@@ -126,6 +132,7 @@ export const HomePageLinks = () => {
       <Column>
         <Button
           as="a"
+          data-trackid={'course-link-big-data-with-r'}
           href="https://www.datacamp.com/tracks/big-data-with-r"
           iconRight={<ExternalLink />}
           size={buttonSize}
@@ -138,12 +145,16 @@ export const HomePageLinks = () => {
           </Paragraph>
           <Link
             css={linkStyle}
+            data-trackid={
+              'course-link-practicing-statistics-interview-questions-in-r'
+            }
             href="https://www.datacamp.com/courses/practicing-statistics-interview-questions-in-r"
           >
             Practicing Interview Questions in R
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'course-link-data-manipulation-with-r'}
             href="https://www.datacamp.com/tracks/data-manipulation-with-r"
           >
             Data Manipulation with R
@@ -153,18 +164,21 @@ export const HomePageLinks = () => {
           </Paragraph>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-tutorial-r-data-import-tutorial'}
             href="https://www.datacamp.com/tutorial/r-data-import-tutorial"
           >
             Importing Data into R
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-tutorial-pca-analysis-r'}
             href="https://www.datacamp.com/tutorial/pca-analysis-r"
           >
             Principal Component Analysis in R
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-tutorial-contingency-tables-r'}
             href="https://www.datacamp.com/tutorial/contingency-tables-r"
           >
             Contingency Tables in R
@@ -174,6 +188,7 @@ export const HomePageLinks = () => {
       <Column>
         <Button
           as="a"
+          data-trackid={'course-link-machine-learning-scientist-with-r'}
           href="https://www.datacamp.com/tracks/machine-learning-scientist-with-r"
           iconRight={<ExternalLink />}
           size={buttonSize}
@@ -186,12 +201,14 @@ export const HomePageLinks = () => {
           </Paragraph>
           <Link
             css={linkStyle}
+            data-trackid={'course-link-machine-learning-in-the-tidyverse'}
             href="https://www.datacamp.com/courses/machine-learning-in-the-tidyverse"
           >
             Machine Learning in the Tidyverse
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={'course-link-supervised-machine-learning-in-r'}
             href="https://www.datacamp.com/tracks/supervised-machine-learning-in-r"
           >
             Supervised Machine Learning in R
@@ -201,12 +218,16 @@ export const HomePageLinks = () => {
           </Paragraph>
           <Link
             css={linkStyle}
+            data-trackid={'tutorial-link-tutorial-decision-trees-r'}
             href="https://www.datacamp.com/tutorial/decision-trees-R"
           >
             Decision Trees in R
           </Link>
           <Link
             css={linkStyle}
+            data-trackid={
+              'tutorial-link-tutorial-supervised-machine-learning-in-r'
+            }
             href="https://www.datacamp.com/tracks/supervised-machine-learning-in-r"
           >
             Hierarchical Clustering in R

--- a/components/HomePageLinks.tsx
+++ b/components/HomePageLinks.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@datacamp/waffles/button';
 import { mediaQuery } from '@datacamp/waffles/helpers';
-import { useMediaQuery } from '@datacamp/waffles/hooks';
 import { ExternalLink } from '@datacamp/waffles/icon';
 import { Link } from '@datacamp/waffles/link';
 import { Paragraph } from '@datacamp/waffles/paragraph';
@@ -73,8 +72,7 @@ const categoryStyle = {
 
 export const HomePageLinks = () => {
   const { theme } = useContext(ThemeContext);
-  const { isAboveSmall } = useMediaQuery();
-  const buttonSize = isAboveSmall ? 'medium' : 'large';
+  const buttonSize = 'large';
   return (
     <ContentWrapper data-theme={theme}>
       <Column>

--- a/components/HomeSearchBar.tsx
+++ b/components/HomeSearchBar.tsx
@@ -3,6 +3,7 @@ import { Button } from '@datacamp/waffles/button';
 import { mediaQuery } from '@datacamp/waffles/helpers';
 import { Search } from '@datacamp/waffles/icon';
 import { Input } from '@datacamp/waffles/input';
+import { lightThemeStyle } from '@datacamp/waffles/theme';
 import { tokens } from '@datacamp/waffles/tokens';
 import styled from '@emotion/styled';
 import { ChangeEvent } from 'react';
@@ -31,7 +32,14 @@ export default function HomeSearchBar({ onChange, value }: Props) {
   const p = PLACEHOLDERS[Math.floor(Math.random() * PLACEHOLDERS.length)];
 
   return (
-    <Wrapper>
+    <Wrapper
+      css={{
+        '&, &[data-theme="light"] *': {
+          ...lightThemeStyle,
+        },
+      }}
+      data-theme={'light'}
+    >
       <Input
         iconLeft={<Search aria-label="Search all packages and functions" />}
         onChange={onChange}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { mediaQuery } from '@datacamp/waffles/helpers';
 import {
   darkThemeStyle,
   lightThemeStyle,
@@ -32,8 +33,11 @@ const ContentWrapper = styled.div({
   flex: 1,
   flexDirection: 'column',
   margin: '0 auto',
-  maxWidth: 1200,
+  maxWidth: '100%',
   padding: `0 ${tokens.spacing.medium}`,
+  [mediaQuery.aboveSmall]: {
+    maxWidth: 1200,
+  },
 });
 
 const Divider = styled.hr({

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -78,6 +78,9 @@ const VerticalDivider = styled.hr(`
 `);
 
 const inputStyle = { flexGrow: 1, minWidth: '343px' };
+const buttonStyle = {
+  height: '36px',
+};
 
 export default function Navbar() {
   const [searchInput, setSearchInput] = useState('');
@@ -144,6 +147,7 @@ export default function Navbar() {
           <Button
             aria-label="toggle dark mode"
             className="p-1"
+            css={{ ...buttonStyle, padding: '12px' }}
             onClick={toggleTheme}
             type="button"
           >
@@ -152,6 +156,7 @@ export default function Navbar() {
           <Button
             aria-label="github repository"
             as="a"
+            css={{ ...buttonStyle, padding: '12px' }}
             href="https://github.com/datacamp/rdocumentation-2.0"
             rel="noopener noreferrer"
             target="_blank"
@@ -160,9 +165,13 @@ export default function Navbar() {
           </Button>
           <Button
             as="a"
+            css={{
+              ...buttonStyle,
+              flexGrow: 1,
+              padding: `${tokens.spacing.small} ${tokens.spacing.medium}`,
+            }}
             href="https://www.datacamp.com/category/r"
             iconLeft={<DataCampBrand />}
-            style={{ flexGrow: 1 }}
             variant="primary"
           >
             Learn R Programming

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,3 +1,4 @@
+/** @jsxImportSource @emotion/react */
 import { DataCampLogo } from '@datacamp/waffles/brand';
 import { Button } from '@datacamp/waffles/button';
 import { Heading } from '@datacamp/waffles/heading';
@@ -12,7 +13,6 @@ import {
 } from '@datacamp/waffles/theme';
 import { tokens } from '@datacamp/waffles/tokens';
 import styled from '@emotion/styled';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useContext, useState } from 'react';
 import { FaGithub } from 'react-icons/fa';
@@ -96,25 +96,33 @@ export default function Navbar() {
   return (
     <Header data-theme={theme}>
       <nav>
-        <Link href="/">
-          <LogoWrapper>
-            <Heading style={{ color: themeTokens.text.main }}>
-              RDocumentation
+        <LogoWrapper>
+          <a href="/">
+            <Heading css={{ color: themeTokens.text.main, margin: 0 }}>
+              Rdocumentation
             </Heading>
-            <div>
-              <VerticalDivider />
-            </div>
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
-              <Paragraph
-                style={{ color: themeTokens.text.secondary }}
-                variant="secondary"
-              >
-                powered by
-              </Paragraph>
-              <DataCampLogo />
-            </div>
-          </LogoWrapper>
-        </Link>
+          </a>
+
+          <div>
+            <VerticalDivider />
+          </div>
+          <a
+            css={{ display: 'flex', flexDirection: 'column' }}
+            href="https://www.datacamp.com"
+          >
+            <Paragraph
+              size="small"
+              style={{
+                color: themeTokens.text.secondary,
+                marginBottom: 0,
+              }}
+              variant="secondary"
+            >
+              powered by
+            </Paragraph>
+            <DataCampLogo css={{ flexShrink: 0, height: 18, width: 86 }} />
+          </a>
+        </LogoWrapper>
       </nav>
 
       <RightContainer>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -79,7 +79,7 @@ const VerticalDivider = styled.hr(`
 
 const inputStyle = { flexGrow: 1, minWidth: '343px' };
 const buttonStyle = {
-  height: '36px',
+  height: tokens.sizing.medium,
 };
 
 export default function Navbar() {

--- a/components/PackageFunctionList.tsx
+++ b/components/PackageFunctionList.tsx
@@ -2,6 +2,7 @@ import { Input } from '@datacamp/waffles/input';
 import { useState } from 'react';
 
 import ClickableCard from './ClickableCard';
+import CourseAds from './CourseAds';
 
 type Props = {
   functions: Array<{
@@ -36,6 +37,7 @@ export default function PackageFunctionList({
 
   return (
     <div>
+      <CourseAds />
       <div className="block md:flex md:items-center md:justify-between">
         <h2 className="text-2xl font-bold">{`Functions in ${packageName} (${packageVersion})`}</h2>
         <div className="mt-5 dc-input md:mt-0">

--- a/helpers/hooks/useRenderCourseAds.ts
+++ b/helpers/hooks/useRenderCourseAds.ts
@@ -1,0 +1,60 @@
+import { useRouter } from 'next/router';
+
+const top50Paths = [
+  '/packages/stats/versions/3.6.2/topics/glm',
+  '/packages/base/versions/3.6.2/topics/merge',
+  '/packages/stats/versions/3.6.2/topics/t.test',
+  '/packages/pheatmap/versions/1.0.12/topics/pheatmap',
+  '/packages/stats/versions/3.6.2/topics/lm',
+  '/packages/graphics/versions/3.6.2/topics/plot',
+  '/packages/base/versions/3.6.2/topics/grep',
+  '/packages/AlphaPart/versions/0.9.8/topics/write.csv',
+  '/packages/base/versions/3.6.2/topics/lapply',
+  '/packages/dplyr/versions/0.7.8/topics/filter',
+  '/packages/base/versions/3.6.2/topics/Round',
+  '/packages/utils/versions/3.6.2/topics/read.table',
+  '/packages/data.table/versions/1.15.4/topics/fread',
+  '/packages/base/versions/3.6.2/topics/ifelse',
+  '/packages/base/versions/3.6.2/topics/data.frame',
+  '/packages/base/versions/3.6.2/topics/as.Date',
+  '/packages/base/versions/3.6.2/topics/sample',
+  '/packages/stats/versions/3.6.2/topics/wilcox.test',
+  '/packages/base/versions/3.6.2/topics/table',
+  '/packages/stats/versions/3.6.2/topics/quantile',
+  '/packages/stats/versions/3.6.2/topics/cor',
+  '/packages/base/versions/3.6.2/topics/cbind',
+  '/packages/xlsx/versions/0.6.5/topics/write.xlsx',
+  '/packages/utils/versions/3.6.2/topics/write.table',
+  '/packages/base/versions/3.6.2/topics/seq',
+  '/packages/readxl/versions/0.1.1/topics/read_excel',
+  '/packages/base/versions/3.6.2/topics/paste',
+  '/packages/stats/versions/3.6.2/topics/p.adjust',
+  '/packages/base/versions/3.6.2/topics/rep',
+  '/packages/base/versions/3.6.2/topics/factor',
+  '/packages/stats/versions/3.6.2/topics/prcomp',
+  '/packages/utils/versions/3.6.2/topics/install.packages',
+  '/packages/stats/versions/3.6.2/topics/optim',
+  '/packages/stats/versions/3.6.2/topics/aggregate',
+  '/packages/stats/versions/3.6.2/topics/hclust',
+  '/packages/base/versions/3.6.2/topics/list.files',
+  '/packages/lme4/versions/1.1-35.5/topics/lmer',
+  '/packages/dplyr/versions/1.0.10/topics/case_when',
+  '/packages/stats/versions/3.6.2/topics/chisq.test',
+  '/packages/base/versions/3.6.2/topics/scale',
+  '/packages/ggpubr/versions/0.6.0/topics/stat_compare_means',
+  '/packages/reshape2/versions/1.4.4/topics/melt',
+  '/packages/dplyr/versions/1.0.10/topics/count',
+  '/packages/graphics/versions/3.6.2/topics/hist',
+  '/packages/stats/versions/3.6.2/topics/cor.test',
+  '/packages/mice/versions/3.16.0/topics/mice',
+  '/packages/forecast/versions/8.23.0/topics/auto.arima',
+  '/packages/base/versions/3.6.2/topics/substr',
+];
+
+export const useRenderCourseAds = () => {
+  const router = useRouter();
+
+  console.log(JSON.stringify(router));
+
+  return top50Paths.includes(router.asPath);
+};

--- a/helpers/hooks/useRenderCourseAds.ts
+++ b/helpers/hooks/useRenderCourseAds.ts
@@ -49,12 +49,13 @@ const top50Paths = [
   '/packages/mice/versions/3.16.0/topics/mice',
   '/packages/forecast/versions/8.23.0/topics/auto.arima',
   '/packages/base/versions/3.6.2/topics/substr',
+  '/packages/survminer/versions/0.4.9/topics/ggsurvplot',
+  '/packages/randomForest/versions/4.7-1.1/topics/randomForest',
+  '/packages/base/versions/3.6.2/topics/mean',
 ];
 
 export const useRenderCourseAds = () => {
   const router = useRouter();
-
-  console.log(JSON.stringify(router));
 
   return top50Paths.includes(router.asPath);
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -51,7 +51,13 @@ export default function HomePage({ packageCount }: { packageCount?: number }) {
       title="Home"
     >
       <SearchWrapper>
-        <Heading as="h2" size="xlarge" style={{ color: themeTokens.text.main }}>
+        <Heading
+          as="h2"
+          size="xxlarge"
+          style={{
+            color: themeTokens.text.main,
+          }}
+        >
           {`Search from ${numberOfPackages} R packages on CRAN and Bioconductor`}
         </Heading>
         <form onSubmit={onSubmitSearch}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,15 +6,13 @@ import { tokens } from '@datacamp/waffles/tokens';
 import styled from '@emotion/styled';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 
 import AutoComplete from '../components/Autocomplete';
 import { HomePageLinks } from '../components/HomePageLinks';
 import HomeSearchBar from '../components/HomeSearchBar';
 import Layout from '../components/Layout';
 import { API_URL } from '../lib/utils';
-
-import { ThemeContext } from './_app';
 
 const SearchWrapper = styled.div({
   margin: `${tokens.spacing.large} 0`,
@@ -28,7 +26,6 @@ const SearchWrapper = styled.div({
 export default function HomePage({ packageCount }: { packageCount?: number }) {
   const [searchInput, setSearchInput] = useState('');
   const router = useRouter();
-  const { theme } = useContext(ThemeContext);
 
   function handleChangeSearchInput(e) {
     setSearchInput(e.target.value);
@@ -53,7 +50,7 @@ export default function HomePage({ packageCount }: { packageCount?: number }) {
       description="Easily search the documentation for every version of every R package on CRAN and Bioconductor."
       title="Home"
     >
-      <SearchWrapper data-theme={theme}>
+      <SearchWrapper>
         <Heading as="h2" size="xlarge" style={{ color: themeTokens.text.main }}>
           {`Search from ${numberOfPackages} R packages on CRAN and Bioconductor`}
         </Heading>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -72,10 +72,11 @@ export default function HomePage({ packageCount }: { packageCount?: number }) {
         as="h3"
         css={{
           color: themeTokens.text.main,
-          textAlign: 'left',
+          fontSize: tokens.fontSizes.large,
           [mediaQuery.aboveMedium]: {
             textAlign: 'center',
           },
+          textAlign: 'left',
         }}
         size="medium"
       >

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource @emotion/react */
+import { tokens } from '@datacamp/waffles/tokens';
 import { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -6,6 +8,7 @@ import ReactGA4 from 'react-ga4';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import atomOneDark from 'react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark';
 
+import CourseAds from '../../../../../../components/CourseAds';
 import Html from '../../../../../../components/Html';
 import Layout from '../../../../../../components/Layout';
 import * as gtag from '../../../../../../lib/gtag';
@@ -79,7 +82,7 @@ export default function TopicPage({ topicData }: Props) {
       description={description}
       title={pageTitle}
     >
-      <div className="max-w-screen-lg mt-8 md:mt-12">
+      <div css={{ marginTop: tokens.spacing.large }}>
         <section className="text-xl text-gray-500">
           <Link href={`/packages/${packageName}/versions/${packageVersion}`}>
             <a>
@@ -202,6 +205,7 @@ export default function TopicPage({ topicData }: Props) {
           )}
         </div>
       </div>
+      <CourseAds />
     </Layout>
   );
 }

--- a/pages/packages/[package]/versions/[version]/topics/[topic].tsx
+++ b/pages/packages/[package]/versions/[version]/topics/[topic].tsx
@@ -135,7 +135,7 @@ export default function TopicPage({ topicData }: Props) {
             <section>
               {sections.map((section) => {
                 if (section.description.length < 1) {
-                  return;
+                  return null;
                 }
                 return (
                   <div key={section.name}>


### PR DESCRIPTION
# Description
## Proposed changes
1. Add a course adds component that is based on a hardcoded list of URLs that are often visited.

<img width="1725" alt="Screenshot 2024-08-29 at 10 10 27" src="https://github.com/user-attachments/assets/5be54902-53db-4b4b-b6a4-fa1915b30c70">


2. Apply style design changes to the homepage
- Fix the logo and the button sizes on the page
- Enforce lightmode for the search bar
- Increase fontsizes
- Link to datacamp when clicking on powered by datacamp and link to / when clicking on rdocumentation
- minor copy changes
<img width="1728" alt="Screenshot 2024-08-29 at 10 07 38" src="https://github.com/user-attachments/assets/76ed711b-ba65-4e5a-822f-8ed72f5efe09">
