### PR TITLE
[OGE-1827] feat: last published date

### DIFF
--- a/pages/packages/[package]/versions/[version].tsx
+++ b/pages/packages/[package]/versions/[version].tsx
@@ -237,8 +237,10 @@ export const getServerSideProps: GetServerSideProps = async ({
       pageTitle,
       readmemd,
       release_date,
+      sourceJSON: { 'Date/Publication': datePublication },
       title,
       topics,
+      updated_at,
       uri,
       version: metadataVersion,
     } = metadata;
@@ -251,7 +253,7 @@ export const getServerSideProps: GetServerSideProps = async ({
       package_name,
       pageTitle,
       readmemd,
-      release_date,
+      release_date: datePublication ? release_date : updated_at,
       title,
       topics: topics.map((topic) => ({
         id: topic.id,


### PR DESCRIPTION
## Changes

- Avoid rendering 1st January 1970 date for last published at (fixes this for all cases)
- When this date is undefined / nullish use the last updated at date for correctness

https://datacamp.atlassian.net/browse/OGE-1827

![Screenshot 2024-09-16 at 09 47 29](https://github.com/user-attachments/assets/1a9c25dc-daca-454d-954e-348f8ed667bd)

![Screenshot 2024-09-16 at 09 47 19](https://github.com/user-attachments/assets/fa7d1aca-8105-4223-b28c-356f4e619b22)
