### PR TITLE
chore: remove the link if the author is not available

### DIFF
--- a/components/PackageSidebar.tsx
+++ b/components/PackageSidebar.tsx
@@ -4,6 +4,7 @@ import { useToast } from '@datacamp/waffles/toast';
 import { format } from 'date-fns';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 import { FaGithub, FaHome, FaUser } from 'react-icons/fa';
 
 import { copyTextToClipboard } from '../lib/utils';
@@ -59,6 +60,7 @@ export default function PackageSidebar({
 }: PackageSidebarProps) {
   const router = useRouter();
   const { toast } = useToast();
+  const [availableAuthor, setAvailableAuthor] = useState(false);
 
   function handleCopyLink() {
     copyTextToClipboard(linkToCurrentVersion);
@@ -69,6 +71,14 @@ export default function PackageSidebar({
     const selectedVersion = event.target.value;
     router.push(`/packages/${packageName}/versions/${selectedVersion}`);
   }
+
+  useEffect(() => {
+    fetch(`/collaborators/name/${encodeURI(maintainer.name)}`).then((res) => {
+      if (res.status === 200) {
+        setAvailableAuthor(true);
+      }
+    });
+  }, [maintainer.name]);
 
   return (
     <div className="space-y-6">
@@ -218,9 +228,13 @@ export default function PackageSidebar({
         <div className="w-1/2">
           <SidebarHeader>Maintainer</SidebarHeader>
           <SidebarValue Icon={FaUser}>
-            <Link href={`/collaborators/name/${encodeURI(maintainer.name)}`}>
-              {maintainer.name}
-            </Link>
+            {availableAuthor ? (
+              <Link href={`/collaborators/name/${encodeURI(maintainer.name)}`}>
+                {maintainer.name}
+              </Link>
+            ) : (
+              maintainer.name
+            )}
           </SidebarValue>
         </div>
         {lastPublished && (

--- a/components/PackageSidebar.tsx
+++ b/components/PackageSidebar.tsx
@@ -4,9 +4,9 @@ import { useToast } from '@datacamp/waffles/toast';
 import { format } from 'date-fns';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 import { FaGithub, FaHome, FaUser } from 'react-icons/fa';
 
+import useHasCollaborator from '../helpers/hooks/useHasCollaborator';
 import { copyTextToClipboard } from '../lib/utils';
 
 import MonthlyDownloadsChart from './MonthlyDownloadsChart';
@@ -60,7 +60,6 @@ export default function PackageSidebar({
 }: PackageSidebarProps) {
   const router = useRouter();
   const { toast } = useToast();
-  const [availableAuthor, setAvailableAuthor] = useState(false);
 
   function handleCopyLink() {
     copyTextToClipboard(linkToCurrentVersion);
@@ -72,13 +71,7 @@ export default function PackageSidebar({
     router.push(`/packages/${packageName}/versions/${selectedVersion}`);
   }
 
-  useEffect(() => {
-    fetch(`/collaborators/name/${encodeURI(maintainer.name)}`).then((res) => {
-      if (res.status === 200) {
-        setAvailableAuthor(true);
-      }
-    });
-  }, [maintainer.name]);
+  const availableAuthor = useHasCollaborator(maintainer.name);
 
   return (
     <div className="space-y-6">

--- a/helpers/hooks/useHasCollaborator.ts
+++ b/helpers/hooks/useHasCollaborator.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+const useHasCollaborator = (name: string): boolean => {
+  const [availableAuthor, setAvailableAuthor] = useState(false);
+
+  useEffect(() => {
+    const fetchCollaborator = async () => {
+      const res = await fetch(`/collaborators/name/${encodeURI(name)}`);
+      setAvailableAuthor(res.status === 200);
+    };
+
+    fetchCollaborator();
+  }, [name]);
+
+  return availableAuthor;
+};
+
+export default useHasCollaborator;


### PR DESCRIPTION
# Proposal
This pull request proposes an update to the `PackageSidebar` component to enhance the handling of the maintainer's information. The changes introduce a new state to track the availability of the maintainer and update the UI accordingly.

# Context
Following the end of Depsy back in 2018, there is no new data incoming - meaning any authors published after March 2018 will throw a 404 on the collaborator/maintainer page on rdocs. 